### PR TITLE
Add Finalize(long offset, Span<byte> hash) to seek in hash's stream

### DIFF
--- a/lib/blake3_dotnet/src/lib.rs
+++ b/lib/blake3_dotnet/src/lib.rs
@@ -93,3 +93,18 @@ pub extern fn blake3_finalize_xof(
   let slice = unsafe { std::slice::from_raw_parts_mut(ptr_out as *mut u8, size as usize) };
   hasher.finalize_xof().fill(slice);
 }
+
+// Finalize the hash, seek to the offset in the hash stream and put the result into output.
+#[no_mangle]
+pub extern fn blake3_finalize_seek_xof(
+  hasher: *mut blake3::Hasher,
+  offset: u64,
+  ptr_out: *mut u8,
+  size: libc::size_t)
+{
+  let hasher = unsafe { &mut *hasher };
+  let slice = unsafe { std::slice::from_raw_parts_mut(ptr_out as *mut u8, size as usize) };
+  let mut reader = hasher.finalize_xof();
+  reader.set_position(offset);
+  reader.fill(slice);
+}

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,15 @@ hasher.Update(Encoding.UTF8.GetBytes("BLAKE3"));
 var hash = hasher.Finalize();
 ```
 
+Or seek in the output "stream" to any position:
+
+```c#
+using var hasher = Blake3.Hasher.New();
+hasher.Update(Encoding.UTF8.GetBytes("BLAKE3"));
+var hashAtPosition = new byte[1024];
+var hash = hasher.Finalize(4242, hashAtPosition);
+```
+
 Or hash a stream on the go with `Blake3Stream`:
 
 ```c#

--- a/src/Blake3/Blake3.props
+++ b/src/Blake3/Blake3.props
@@ -3,7 +3,7 @@
     <Description>Blake3.NET is a managed wrapper around the Rust implementations of the BLAKE3 cryptographic hash function.</Description>
     <Copyright>Alexandre Mutel</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <!--<VersionSuffix>alpha</VersionSuffix>
     <BuildNumber>9</BuildNumber>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' AND '$(BuildNumber)' != ''">$(VersionSuffix).$(BuildNumber)</VersionSuffix>-->

--- a/src/Blake3/Hasher.cs
+++ b/src/Blake3/Hasher.cs
@@ -248,6 +248,37 @@ namespace Blake3
         }
 
         /// <summary>
+        /// Finalize the hash state to the output span, which can supply any number of output bytes.
+        /// </summary>
+        /// <param name="offset">The offset to seek to in the output stream, relative to the start.</param>
+        /// <param name="hash">The output hash, which can supply any number of output bytes.</param>
+        /// <remarks>
+        /// This method is idempotent. Calling it twice will give the same result. You can also add more input and finalize again.
+        /// </remarks>
+        public void Finalize(ulong offset, Span<byte> hash)
+        {
+            if (_hasher == null) ThrowNullReferenceException();
+            ref var pData = ref MemoryMarshal.GetReference(hash);
+            fixed (void* ptr = &pData)
+            {
+                blake3_finalize_seek_xof(_hasher, offset, ptr, (void*)(IntPtr)hash.Length);
+            }
+        }
+
+        /// <summary>
+        /// Finalize the hash state to the output span, which can supply any number of output bytes.
+        /// </summary>
+        /// <param name="offset">The offset to seek to in the output stream, relative to the start.</param>
+        /// <param name="hash">The output hash, which can supply any number of output bytes.</param>
+        /// <remarks>
+        /// This method is idempotent. Calling it twice will give the same result. You can also add more input and finalize again.
+        /// </remarks>
+        public void Finalize(long offset, Span<byte> hash)
+        {
+            Finalize((ulong)offset, hash);
+        }
+
+        /// <summary>
         /// Construct a new Hasher for the regular hash function.
         /// </summary>
         /// <returns>A new instance of the hasher</returns>
@@ -380,5 +411,9 @@ namespace Blake3
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         [SuppressGCTransition]
         private static extern void blake3_finalize_xof(void* hasher, void* ptr, void* size);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        [SuppressGCTransition]
+        private static extern void blake3_finalize_seek_xof(void* hasher, ulong offset, void* ptr, void* size);
     }
 }


### PR DESCRIPTION
This is useful to (among other potential uses) use Blake3 as a PRNG (maybe even CPRNG): using a single seed, you can potentially generate up to 2^64-1/32 256bits "keys".

The TestUpdateAndUpdateJoinGiveSameHash test is not directly related to this PR, but at some point I had a doubt regarding the output of those two functions, and I'd have liked to see such a test to confirm that their output is supposed to be the same.

I wasn't sure if I was supposed to commit the updated blake3_dotnet binaries, but in any case I don't have the setup to generate all of them right now.

Thanks!