### PR TITLE
Fixed Blake3Stream::Read methods

### DIFF
--- a/src/Blake3.Tests/Blake3StreamTests.cs
+++ b/src/Blake3.Tests/Blake3StreamTests.cs
@@ -21,6 +21,37 @@ namespace Blake3.Tests
             AssertTextAreEqual(HasherTests.BigExpected, blake3Stream.ComputeHash().ToString());
         }
 
+        private static int FillBuffer(Stream stream, ref byte[] buffer)
+        {
+           int read;
+           int totalRead = 0;
+           do
+           {
+              read = stream.Read(buffer, totalRead, buffer.Length - totalRead);
+              totalRead += read;
+           } while (read > 0 && totalRead < buffer.Length);
+
+           return totalRead;
+        }
+
+        [Test]
+        public void TestHashBufferedRead()
+        {
+           var stream = new MemoryStream(HasherTests.BigData);
+           using var blake3Stream = new Blake3Stream(stream);
+
+           const int bufferSize = 8 * 1024;
+           var buffer = new byte[bufferSize];
+           do
+           {
+              int bufferDataLength = FillBuffer(blake3Stream, ref buffer);
+              if (bufferDataLength == 0)
+                 break;
+           } while (true);
+
+           AssertTextAreEqual(HasherTests.BigExpected, blake3Stream.ComputeHash().ToString());
+        }
+        
         [Test]
         public void TestHashWrite()
         {

--- a/src/Blake3/Blake3Stream.cs
+++ b/src/Blake3/Blake3Stream.cs
@@ -83,7 +83,7 @@ namespace Blake3
             var length = _stream.Read(buffer, offset, count);
             if (length > 0)
             {
-                var span = new Span<byte>(buffer, offset, count);
+                var span = new Span<byte>(buffer, offset, length);
                 _hasher.Update(span);
             }
             return length;
@@ -94,7 +94,7 @@ namespace Blake3
             var length = await _stream.ReadAsync(buffer, offset, count, cancellationToken);
             if (length > 0)
             {
-                _hasher.Update(new Span<byte>(buffer, offset, count));
+                _hasher.Update(new Span<byte>(buffer, offset, length));
             }
             return length;
         }


### PR DESCRIPTION
Now the Read methods can be used for buffered reading.
cf. TestHashBufferedRead
