### PR TITLE
fix: resolve 5 bugs in .NET managed layer

### DIFF
--- a/src/Blake3.Tests/Blake3StreamTests.cs
+++ b/src/Blake3.Tests/Blake3StreamTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Blake3.Tests
@@ -55,6 +57,38 @@ namespace Blake3.Tests
             using var blake3Stream = new Blake3Stream(stream);
             blake3Stream.Write(HasherTests.BigData);
             AssertTextAreEqual(HasherTests.BigExpected, blake3Stream.ComputeHash().ToString());
+        }
+
+        [Test]
+        public void TestHashReadSpan_PartialRead()
+        {
+            var data = HasherTests.SimpleData;
+            var expected = HasherTests.SimpleExpected;
+
+            var stream = new MemoryStream(data);
+            using var blake3Stream = new Blake3Stream(stream);
+
+            var oversizedBuffer = new byte[data.Length + 1024];
+            var bytesRead = blake3Stream.Read(oversizedBuffer.AsSpan());
+
+            Assert.AreEqual(data.Length, bytesRead);
+            AssertTextAreEqual(expected, blake3Stream.ComputeHash().ToString());
+        }
+
+        [Test]
+        public async Task TestHashReadAsyncMemory_PartialRead()
+        {
+            var data = HasherTests.SimpleData;
+            var expected = HasherTests.SimpleExpected;
+
+            var stream = new MemoryStream(data);
+            await using var blake3Stream = new Blake3Stream(stream);
+
+            var oversizedBuffer = new byte[data.Length + 1024];
+            var bytesRead = await blake3Stream.ReadAsync(oversizedBuffer.AsMemory());
+
+            Assert.AreEqual(data.Length, bytesRead);
+            AssertTextAreEqual(expected, blake3Stream.ComputeHash().ToString());
         }
     }
 }

--- a/src/Blake3.Tests/HasherTests.cs
+++ b/src/Blake3.Tests/HasherTests.cs
@@ -110,5 +110,25 @@ namespace Blake3.Tests
 
             Assert.True(bigHash.SequenceEqual(reconstructedHash.ToArray()));
         }
+
+        [Test]
+        public void TestUpdateWithJoinEmptySpan()
+        {
+            using var hasher = Hasher.New();
+            hasher.UpdateWithJoin(ReadOnlySpan<byte>.Empty);
+            var hash = hasher.Finalize();
+            using var hasher2 = Hasher.New();
+            var expected = hasher2.Finalize();
+            Assert.AreEqual(expected, hash);
+        }
+
+        [Test]
+        public void TestFinalizeWithNegativeOffset()
+        {
+            using var hasher = Hasher.New();
+            hasher.Update(SimpleData);
+            var output = new byte[32];
+            Assert.Throws<ArgumentOutOfRangeException>(() => hasher.Finalize(-1L, output));
+        }
     }
 }

--- a/src/Blake3/Blake3Stream.cs
+++ b/src/Blake3/Blake3Stream.cs
@@ -101,7 +101,7 @@ public class Blake3Stream : Stream
         var length = await _stream.ReadAsync(buffer, cancellationToken);
         if (length > 0)
         {
-            _hasher.Update(buffer.Span);
+            _hasher.Update(buffer.Span.Slice(0, length));
         }
         return length;
     }
@@ -111,7 +111,7 @@ public class Blake3Stream : Stream
         var length = _stream.Read(buffer);
         if (length > 0)
         {
-            _hasher.Update(buffer);
+            _hasher.Update(buffer.Slice(0, length));
         }
         return length;
     }

--- a/src/Blake3/Hash.cs
+++ b/src/Blake3/Hash.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 
 namespace Blake3;
 
@@ -85,7 +86,7 @@ public struct Hash : IEquatable<Hash>
 
     public bool Equals(Hash other)
     {
-        return this.AsSpan().SequenceCompareTo(other.AsSpan()) == 0;
+        return CryptographicOperations.FixedTimeEquals(AsSpan(), other.AsSpan());
     }
 
     public override bool Equals(object obj)

--- a/src/Blake3/Hasher.cs
+++ b/src/Blake3/Hasher.cs
@@ -183,7 +183,6 @@ public unsafe partial struct Hasher : IDisposable
     /// </remarks>
     public void UpdateWithJoin(ReadOnlySpan<byte> data)
     {
-        if (data == null) ThrowArgumentNullException();
         if (_hasher == null) ThrowNullReferenceException();
         fixed (void* ptr = data)
         {
@@ -283,6 +282,7 @@ public unsafe partial struct Hasher : IDisposable
     /// </remarks>
     public void Finalize(long offset, Span<byte> hash)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(offset, 0);
         Finalize((ulong)offset, hash);
     }
 


### PR DESCRIPTION
## Summary

- **`Hash.Equals` is not constant-time**: `SequenceCompareTo` short-circuits on the first differing byte, making it vulnerable to timing attacks. Replaced with `CryptographicOperations.FixedTimeEquals`. This contradicts the doc comment which states "constant-time equality checking".
- **`Blake3Stream.Read(Span<byte>)` hashes wrong data**: when the buffer is larger than the data available, the entire buffer (including unread garbage bytes) is hashed instead of only the bytes actually read. Fixed by slicing to `length`.
- **`Blake3Stream.ReadAsync(Memory<byte>)` same issue**: the async overload has the identical bug. Fixed the same way.
- **`Hasher.UpdateWithJoin` incorrect empty span handling**: `ReadOnlySpan<byte> == null` is equivalent to checking `IsEmpty`, which causes `UpdateWithJoin` to throw `ArgumentNullException` on empty input. This is inconsistent with `Update` and `UpdateWithJoin<T>`, which accept empty spans without throwing. Removed the check.
- **`Hasher.Finalize(long, Span<byte>)` missing negative offset validation**: a negative `long` is silently cast to a huge `ulong`. Added `ArgumentOutOfRangeException.ThrowIfLessThan(offset, 0)`.